### PR TITLE
Feat/create abstract entity

### DIFF
--- a/src/core/domain/Entity.spec.ts
+++ b/src/core/domain/Entity.spec.ts
@@ -1,0 +1,30 @@
+import { Entity } from "./Entity";
+
+class CustomEntity extends Entity<{}> {}
+
+describe("Core Entity", () => {
+  it("should generate an ID if not provided", () => {
+    const entity = new CustomEntity({});
+
+    expect(entity.id).toBeTruthy();
+  });
+
+  it("should use the provided ID if provided", () => {
+    const entity = new CustomEntity({}, "custom-id");
+
+    expect(entity.id).toEqual("custom-id");
+  });
+
+  it("should be able to check equality", () => {
+    const entityOne = new CustomEntity({}, "same-id");
+    const entityTwo = new CustomEntity({}, "same-id");
+
+    class Another {}
+
+    expect(entityOne.equals(undefined)).toBe(false);
+    expect(entityOne.equals(new Another() as any)).toBe(false);
+
+    expect(entityOne.equals(entityOne)).toBe(true);
+    expect(entityOne.equals(entityTwo)).toBe(true);
+  });
+});

--- a/src/core/domain/Entity.ts
+++ b/src/core/domain/Entity.ts
@@ -1,0 +1,34 @@
+import { v4 as uuid } from "uuid";
+
+abstract class Entity<T> {
+  protected readonly _id: string;
+
+  public readonly props: T;
+
+  get id() {
+    return this._id;
+  }
+
+  constructor(props: T, id?: string) {
+    this._id = id || uuid();
+    this.props = props;
+  }
+
+  public equals(object?: Entity<T>): boolean {
+    if (object === null || object === undefined) {
+      return false;
+    }
+
+    if (this === object) {
+      return true;
+    }
+
+    if (!(object instanceof Entity)) {
+      return false;
+    }
+
+    return this._id === object._id;
+  }
+}
+
+export { Entity };


### PR DESCRIPTION
Foi implementada uma classe abstrata para servir de base para as entidades do domínio que serão criadas.
Essa classe contem:
- `id` único
- Função de comparação